### PR TITLE
Capture of Chapel's current governance model

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,9 +28,10 @@ efforts being done across the project.
 
 As a founding member of the Chapel project who has been continually
 involved with it since the outset, Brad has served in this role since
-2006.  In practice, he serves as something of a
-[BDFL](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life)
-role for the project to date.
+2006 after inheriting it from David Callahan.  Generally speaking,
+Brad strives to follow the direction of the community when that is
+clear.  He has the ability to serve as an authority in decision-making
+cases, as noted [below](#decision-making).
 
 
 **Subteam Leads**
@@ -55,33 +56,32 @@ At present, the Chapel subteam leads are as follows:
 * User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)
 
 
-Core Contributors
------------------
+Committers
+----------
 
-Role: Core contributors are those who have merge privileges to the
+Role: Committers are those who have merge-commit privileges to the
 [main Chapel repository](https://github.com/chapel-lang/chapel).
 These team members are expected to participate in reviewing PRs for
-appropriateness, consistency, and potential security issues.  Core
-contributors are also typically expected to help with triaging
-failures in the nightly regression tests, though exceptions are often
-made for those who are also serving as managers on the team or
+appropriateness, consistency, and potential security issues.
+Committers are also typically expected to help with triaging failures
+in the nightly regression tests on a rotating basis, though exceptions
+are made for those who are also serving as managers on the team or
 spending most of their time on other projects.
 
-All PRs are expected to be reviewed by at least one core contributor
-other than the PR's author; specifically, PRs created by a core
-contributor should typically be reviewed by another core contributor.
-An exception exists for PRs considered "trivial"—so simple or
-straightforward that asking for a review would feel like a waste of a
-colleague's time rather than a benefit to the project.  When in doubt,
-a review should be requested.  Core contributors who don't feel
-confident reviewing a PR will typically call in additional core
-contributors to help with the review or provide additional thoughts.
-A core contributor who authors or merges a PR is typically responsible
-for any testing fallout caused by that PR, typically by involving the
-PR's author when it was not theirs.  In some cases, the reviewing core
-contributor or another volunteer may step up to help out.
+All PRs are expected to be reviewed by at least one committer other
+than the PR's author; specifically, PRs created by a committer should
+typically be reviewed by another committer.  An exception exists for
+PRs considered "trivial"—so simple or straightforward that asking for
+a review would feel like a waste of a colleague's time rather than a
+benefit to the project.  When in doubt, a review should be requested.
+Committers who don't feel confident reviewing a PR will typically call
+in additional committers to help with the review or provide additional
+thoughts.  A committer who authors or merges a PR is typically
+responsible for any testing fallout caused by that PR, typically by
+involving the PR's author when it was not theirs.  In some cases, the
+reviewing committer or another volunteer may step up to help out.
 
-At present, the list of core contributors includes all of the
+At present, the list of committers includes all of the
 technical leaders listed previously, as well as:
 
 * [Jade Abraham](https://github.com/jabraham17)
@@ -105,15 +105,24 @@ Decision-Making
 ---------------
 
 Generally speaking, decision-making on the Chapel project is done by
-the technical leadership and core contributors in this section on a
-consensus basis, taking the opinions of end-users into account when
-the decision is likely to affect them.
+the technical leadership and committers in this section on a consensus
+basis, taking the opinions of end-users into account when the decision
+is likely to affect them.  Project-wide decisions tend to involve all
+technical leads and committers, while those that are specific to a
+given effort can be made by a subteam lead and its members, keeping
+the tech lead apprised of key decisions.
 
-For non-trivial internal decisions, or initial explorations into
-public decisions, the project typically forms an ad hoc subteam of at
-least three core contributors to explore the topic and propose a
-solution, where anyone on the team is encouraged to participate if
-they are interested.  Once the subteam has reached a conclusion, it is
+Votes are rarely taken in a binding manner, but are often used to
+gauge the level of support for an idea or direction.  In such votes,
+those in the minority are typically given the opportunity to continue
+to push for alternative approaches, or to concede to the majority,
+having registered their opinion.
+
+For non-trivial decisions, or initial explorations into possible
+directions, the project typically forms an ad hoc subteam including at
+least three committers to explore the topic and propose a solution,
+where anyone on the team is encouraged to participate if they are
+interested.  Once the subteam has reached a conclusion, it is
 summarized back to the full team.  Generally speaking, those who did
 not join the subteam are expected to go along with the subteam's
 decision, unless they have an insight or strong reason that the
@@ -131,7 +140,10 @@ to get their feedback by pointing them to the GitHub issues or
 contacting them directly.  For some of the most impactful changes, we
 have run polls and worked hard to involve as many users as possible in
 order to avoid surprises and attempt to develop a consensus community
-view.
+view.  In extreme cases, the tech lead may veto a decision, though it
+is expected that this would be used only very rarely.  They may also
+serve as a final decision-maker in the event that the community can't
+come to a decision.
 
 
 Community Contributors

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -78,7 +78,7 @@ Committers who don't feel confident reviewing a PR will typically call
 in additional committers to help with the review or provide additional
 thoughts.  A committer who authors or merges a PR is typically
 responsible for any testing fallout caused by that PR, typically by
-involving the PR's author when it was not theirs.  In some cases, the
+involving the author when the PR was not theirs.  In some cases, the
 reviewing committer or another volunteer may step up to help out.
 
 At present, the list of committers includes all of the
@@ -119,7 +119,7 @@ to push for alternative approaches, or to concede to the majority,
 having registered their opinion.
 
 For non-trivial decisions in language design, library APIs, or code
-architecture, the project or subteam typically forms an ad hoc subteam
+architecture, the project or subteam often forms an ad hoc subteam
 including at least three committers to explore the topic and propose a
 solution, where anyone on the broader team is encouraged to
 participate if they feel interested or invested.  Once the ad hoc
@@ -137,14 +137,14 @@ Design`](https://github.com/chapel-lang/chapel/issues?q=is%3Aissue%20label%3A%22
 as a means of soliciting input from the community. Many of these
 issues are opened or requested by users directly. Decisions that are
 particularly impactful to user codes are advertised directly to users
-to get their feedback by pointing them to the GitHub issues or
+to get their feedback, by pointing them to the GitHub issues or
 contacting them directly.  For some of the most impactful changes, we
-have run polls and worked hard to involve as many users as possible in
-order to avoid surprises and attempt to develop a consensus community
-view.  The technical lead may serve as a final decision-maker in the
-event that the community can't come to a decision.  In extreme cases,
-the technical lead may veto a decision, though it is expected that
-this would be used only very rarely.
+run polls and work hard to involve as many users as possible in order
+to avoid surprises and attempt to develop a consensus community view.
+The technical lead may serve as a final decision-maker in the event
+that the community can't come to a decision.  In extreme cases, the
+technical lead may veto a decision, though it is expected that this
+would be used only very rarely.
 
 
 
@@ -153,12 +153,12 @@ Community Contributors
 
 Role: This role describes those who have contributed code or
 documentation changes that are part of the project's release
-artifacts, typically by directly opening a [pull request (PR) against
-the main project
-repository](https://github.com/chapel-lang/chapel/pulls) that contains
-their commits to improve the code base and/or documentation.  The
-commits within a PR must be signed off to certify conformance with the
-[Developers Certificate of Origin
+artifacts.  Such contributions are typically made by directly opening
+a [pull request (PR) against the main project
+repository](https://github.com/chapel-lang/chapel/pulls) containing
+and explaining their proposed changes.  The commits within such PRs
+must be signed to certify conformance with the [Developer Certificate
+of Origin
 (DCO)](https://github.com/chapel-lang/chapel/blob/main/.github/CONTRIBUTING.md).
 
 As noted above, such PRs must be reviewed and merged by a core
@@ -184,6 +184,6 @@ suggestions, questions, feature requests, bug reports, and the like
 Such contributions are invaluable to the project's effort, and Chapel
 has improved immensely over time as a result of them.  We do not
 currently track a list of people in this role due to the challenge in
-doing so, but it is easy to identify many such individuals through
-their actions on GitHub and in our [community
-forums](https://chapel-lang.org/community/).
+doing so accurately and completely, but it is possible to identify
+many such individuals through their interactions on GitHub and in our
+[community forums](https://chapel-lang.org/community/).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -131,11 +131,15 @@ documentation changes that are part of the project's release
 artifacts, typically by directly opening a [pull request (PR) against
 the main project
 repository](https://github.com/chapel-lang/chapel/pulls) that contains
-their commits to improve the code base or documentation.  As noted
-above, such PRs must be reviewed and merged by a core contributor as a
-means of maintaining and improving the quality of the code base, and
-to help manage any fallout that may show up afterwards, such as
-failures or performance regressions in the nightly testing.
+their commits to improve the code base or documentation.  The commits
+within a PR must be signed off to certify conformance with the
+[Developers Certificate of
+Origin](https://github.com/chapel-lang/chapel/blob/main/.github/CONTRIBUTING.md).
+
+As noted above, such PRs must be reviewed and merged by a core
+contributor as a means of maintaining and improving the quality of the
+code base, and to help manage any fallout that may show up afterwards,
+such as failures or performance regressions in the nightly testing.
 
 Our project tracks the list of core and community contributors in the
 main repository's
@@ -143,3 +147,16 @@ main repository's
 file, separately identifying those who have contributed to the most
 recent release as a means of giving distinction to those who have been
 active most recently.
+
+
+## Community Collaborators and Users
+
+Role: This role describes those who are active in the community and
+aid us in making the Chapel language and implementation better through
+suggestions, questions, feature requests, corrections, and the like
+rather than through specific contributions of code and documentation.
+We greatly value such contributions to the effort, and our project has
+improved immensely as a result of it.  We do not currently track a
+list of people in this role because of its ephemeral nature, but it is
+not difficult to find such contributors in our [community
+forums](https://chapel-lang.org/community/), present and past.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -118,17 +118,17 @@ those in the minority are typically given the opportunity to continue
 to push for alternative approaches, or to concede to the majority,
 having registered their opinion.
 
-For non-trivial decisions, or initial explorations into possible
-directions, the project typically forms an ad hoc subteam including at
-least three committers to explore the topic and propose a solution,
-where anyone on the team is encouraged to participate if they are
-interested.  Once the subteam has reached a conclusion, it is
-summarized back to the full team.  Generally speaking, those who did
-not join the subteam are expected to go along with the subteam's
-decision, unless they have an insight or strong reason that the
-proposal is untenable—particularly if it involves factors the subteam
-was not, or could not have been, aware of.  In practice, this has
-happened only very rarely.
+For non-trivial decisions in language design, library APIs, or code
+architecture, the project or subteam typically forms an ad hoc subteam
+including at least three committers to explore the topic and propose a
+solution, where anyone on the broader team is encouraged to
+participate if they feel interested or invested.  Once the ad hoc
+subteam has reached a conclusion, it is summarized back to the full
+team.  Generally speaking, those who did not join the ad hoc subteam
+are expected to go along with its decision, unless they have an
+insight or strong reason that the proposal is untenable—particularly
+if it involves factors the subteam was not, or could not have been,
+aware of.  In practice, this has happened only very rarely.
 
 Decisions that relate to the design of the language or libraries are
 captured and discussed on public [GitHub

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,41 +2,47 @@
 
 This file describes the current governance of the Chapel Language
 project, covering both the language's definition and the code base
-implementing its compiler, library modules, and runtime.  It was last
-updated in January 2025.
+that implements its compiler, library modules, and runtime.  It was
+last updated in January 2025.
 
-We anticipate improving the Chapel project's governance, with the aim
-of making it more of a community-governed project, over time.  If this
-is of interest to you, please let us know.  If you have specific
-requests with respect to how the project is governed, please open an
-issue on this repository.
+Over time, we anticipate improving the Chapel project's governance,
+with the goal of making it more of a community-governed project.  If
+this topic is of interest to you, or you would like to play a role in
+that transition or its result, please let us know.  If you have
+specific requests with respect to how the project is governed, please
+feel encouraged to capture those in an issue on this repository, or to
+[reach out to the community](https://chapel-lang.org/community/).
 
 
 ## Technical Leadership
 
 **Technical Lead:** [Brad Chamberlain](bradcray)
 
-Role: Generally speaking, the role of the project technical lead is to
-help guide technical decisions for the project in ways that are
+Role: Generally speaking, the role of the project technical lead has
+been to help guide decisions for the project in ways that are
 technically sound, responsive to user needs and concerns, cognizant of
-the project's history and past direction, and compatible with other
-decisions being made across the project.  As a founding member of the
-Chapel project who has been continually involved with it since the
-outset, Brad has served in this role since ~2006, making him something
-like the project's BDFL.
+the project's history and past decisions, and compatible with other
+efforts being done across the project.
+
+As a founding member of the Chapel project who has been continually
+involved with it since the outset, Brad has served in this role since
+2006.  In practice, he serves as something of a
+[BDFL](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life)
+role for the project to date.
 
 
 **Subteam Leads**
 
 Role: As the scope of the Chapel project has grown, a number of
-subteams have been formed to focus on specific initiatives at finer
+subteams have been spun up to focus on specific initiatives at finer
 granularities.  Generally speaking, these subteam leads have a great
-deal of latitude in making decisions supporting their goals, but are
-encouraged to keep the technical lead in the loop, particularly for
-decisions that are contentious, represent a significant change in
-direction, or have the possibility of impacting other subteams.
+deal of latitude in making decisions to meet their goals, but are
+expected to keep the technical lead aware of major decisions,
+particularly for those that are contentious, represent a significant
+change in direction, or have the possibility of impacting other
+subteams.
 
-At present, the subteam leads are as follows:
+At present, the Chapel subteam leads are as follows:
 
 * Community Management: [Brandon Neth](https://github.com/brandon-neth)
 * Compiler: [Ben Harshbarger](https://github.com/benharsh)
@@ -47,7 +53,7 @@ At present, the subteam leads are as follows:
 * User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)
 
 
-**Core Contributors**
+## Core Contributors
 
 Role: Core contributors are those who have merge privileges to the
 [main Chapel repository](https://github.com/chapel-lang/chapel).
@@ -55,9 +61,8 @@ These team members are expected to participate in reviewing PRs for
 appropriateness, consistency, and potential security issues.  Core
 contributors are also typically expected to help with triaging
 failures in the nightly regression tests, though exceptions are often
-made for core contributors who are also serving as managers on the
-team, focusing on DevOps or Build/Test/Release issues, or spending
-most of their time on other projects.
+made for those who are also serving as managers on the team or
+spending most of their time on other projects.
 
 All PRs are expected to be reviewed by at least one core contributor
 other than the PR's author; specifically, PRs created by a core
@@ -70,8 +75,8 @@ confident reviewing a PR will typically call in additional core
 contributors to help with the review or provide additional thoughts.
 A core contributor who authors or merges a PR is typically responsible
 for any testing fallout caused by that PR, typically by involving the
-PR's author.  In some cases, the reviewing core contributor or another
-volunteer may step up to help out.
+PR's author when it was not theirs.  In some cases, the reviewing core
+contributor or another volunteer may step up to help out.
 
 At present, the list of core contributors includes all of the
 technical leaders listed previously, as well as:
@@ -93,12 +98,12 @@ technical leaders listed previously, as well as:
 * [Karlon West](https://github.com/karlonw)
 
 
-** Decision-Making **
+## Decision-Making
 
 Generally speaking, decision-making on the Chapel project is done by
-the technical leadership and contributors in this section on a
+the technical leadership and core contributors in this section on a
 consensus basis, taking the opinions of end-users into account when
-the decision is likely to effect them.
+the decision is likely to affect them.
 
 For non-trivial internal decisions, or initial explorations into
 public decisions, the project typically forms an ad hoc subteam of at
@@ -108,8 +113,9 @@ they are interested.  Once the subteam has reached a conclusion, it is
 summarized back to the full team.  Generally speaking, those who did
 not join the subteam are expected to go along with the subteam's
 decision, unless they have an insight or strong reason that the
-proposal is untenable, particularly if it involves factors the subteam
-was unaware of.  In practice, this happens only very rarely.
+proposal is untenable—particularly if it involves factors the subteam
+was not, or could not have been, aware of.  In practice, this has
+happened only very rarely.
 
 Decisions that relate to the design of the language or libraries are
 captured and discussed on public [GitHub
@@ -131,10 +137,10 @@ documentation changes that are part of the project's release
 artifacts, typically by directly opening a [pull request (PR) against
 the main project
 repository](https://github.com/chapel-lang/chapel/pulls) that contains
-their commits to improve the code base or documentation.  The commits
-within a PR must be signed off to certify conformance with the
-[Developers Certificate of
-Origin](https://github.com/chapel-lang/chapel/blob/main/.github/CONTRIBUTING.md).
+their commits to improve the code base and/or documentation.  The
+commits within a PR must be signed off to certify conformance with the
+[Developers Certificate of Origin
+(DCO)](https://github.com/chapel-lang/chapel/blob/main/.github/CONTRIBUTING.md).
 
 As noted above, such PRs must be reviewed and merged by a core
 contributor as a means of maintaining and improving the quality of the
@@ -153,10 +159,11 @@ active most recently.
 
 Role: This role describes those who are active in the community and
 aid us in making the Chapel language and implementation better through
-suggestions, questions, feature requests, corrections, and the like
-rather than through specific contributions of code and documentation.
-We greatly value such contributions to the effort, and our project has
-improved immensely as a result of it.  We do not currently track a
-list of people in this role because of its ephemeral nature, but it is
-not difficult to find such contributors in our [community
-forums](https://chapel-lang.org/community/), present and past.
+suggestions, questions, feature requests, bug reports, and the like
+(rather than through direct contributions of code or documentation).
+Such contributions are invaluable to the project's effort, and Chapel
+has improved immensely over time as a result of it.  We do not
+currently track a list of people in this role due to the challenge in
+doing so, but it is easy to identify many such individuals through
+their actions on GitHub and in our [community
+forums](https://chapel-lang.org/community/).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -132,8 +132,8 @@ could not have been, aware of.  In practice, this has happened only
 very rarely.
 
 Decisions that relate to the design of the language or libraries are
-captured and discussed on public [GitHub
-issues](https://github.com/chapel-lang/chapel/issues?q=is%3Aissue%20label%3A%22type%3A%20Design%22)
+captured and discussed on public [GitHub issues labeled with `type:
+Design`](https://github.com/chapel-lang/chapel/issues?q=is%3Aissue%20label%3A%22type%3A%20Design%22)
 as a means of soliciting input from the community. Many of these
 issues are opened or requested by users directly. Decisions that are
 particularly impactful to user codes are advertised directly to users

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -39,8 +39,8 @@ cases, as noted [below](#decision-making).
 Role: As the scope of the Chapel project has grown, a number of
 subteams have been spun up to focus on specific initiatives at finer
 granularities.  Generally speaking, these subteam leads have a great
-deal of latitude in making decisions to meet their goals, but are
-expected to keep the technical lead aware of major decisions,
+deal of latitude in making decisions to meet their subteams' goals,
+but are expected to keep the technical lead aware of major decisions,
 particularly for those that are contentious, represent a significant
 change in direction, or have the possibility of impacting other
 subteams.
@@ -52,7 +52,7 @@ At present, the Chapel subteam leads are as follows:
 * DevOps: [Tim Zinsky](https://github.com/tzinsky)
 * GPU: [Engin Kayraklioglu](https://github.com/e-kayrakli)
 * Performance: [Andy Stone](https://github.com/stonea)
-* Runtime / Platform / Portability: [John Hartman](https://github.com/jhh67)
+* Runtime, Platform, and Portability: [John Hartman](https://github.com/jhh67)
 * User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)
 
 
@@ -105,12 +105,12 @@ Decision-Making
 ---------------
 
 Generally speaking, decision-making on the Chapel project is done by
-the technical leadership and committers in this section on a consensus
-basis, taking the opinions of end-users into account when the decision
-is likely to affect them.  Project-wide decisions tend to involve all
-technical leads and committers, while those that are specific to a
-given effort can be made by a subteam lead and its members, keeping
-the tech lead apprised of key decisions.
+the technical leadership and committers on a consensus basis, taking
+the opinions of end-users into account when the decision is likely to
+affect them.  Project-wide decisions tend to involve all technical
+leads and committers, while those that are specific to a given effort
+can be made by a subteam lead and its members, keeping the technical
+lead apprised of key decisions.
 
 Votes are rarely taken in a binding manner, but are often used to
 gauge the level of support for an idea or direction.  In such votes,
@@ -124,26 +124,28 @@ including at least three committers to explore the topic and propose a
 solution, where anyone on the broader team is encouraged to
 participate if they feel interested or invested.  Once the ad hoc
 subteam has reached a conclusion, it is summarized back to the full
-team.  Generally speaking, those who did not join the ad hoc subteam
-are expected to go along with its decision, unless they have an
-insight or strong reason that the proposal is untenable—particularly
-if it involves factors the subteam was not, or could not have been,
-aware of.  In practice, this has happened only very rarely.
+team.  Generally speaking, those who did not volunteer to join the ad
+hoc subteam are expected to go along with its decision, unless they
+have an insight or strong reason that the proposal is
+untenable—particularly if it involves factors the subteam was not, or
+could not have been, aware of.  In practice, this has happened only
+very rarely.
 
 Decisions that relate to the design of the language or libraries are
 captured and discussed on public [GitHub
-issues](https://github.com/chapel-lang/chapel/issues?q=is%3Aissue) as
-a means of soliciting input from the community. Many of these issues
-are opened or requested by users directly. Decisions that are
+issues](https://github.com/chapel-lang/chapel/issues?q=is%3Aissue%20label%3A%22type%3A%20Design%22)
+as a means of soliciting input from the community. Many of these
+issues are opened or requested by users directly. Decisions that are
 particularly impactful to user codes are advertised directly to users
 to get their feedback by pointing them to the GitHub issues or
 contacting them directly.  For some of the most impactful changes, we
 have run polls and worked hard to involve as many users as possible in
 order to avoid surprises and attempt to develop a consensus community
-view.  In extreme cases, the tech lead may veto a decision, though it
-is expected that this would be used only very rarely.  They may also
-serve as a final decision-maker in the event that the community can't
-come to a decision.
+view.  The technical lead may serve as a final decision-maker in the
+event that the community can't come to a decision.  In extreme cases,
+the technical lead may veto a decision, though it is expected that
+this would be used only very rarely.
+
 
 
 Community Contributors
@@ -180,7 +182,7 @@ aid us in making the Chapel language and implementation better through
 suggestions, questions, feature requests, bug reports, and the like
 (rather than through direct contributions of code or documentation).
 Such contributions are invaluable to the project's effort, and Chapel
-has improved immensely over time as a result of it.  We do not
+has improved immensely over time as a result of them.  We do not
 currently track a list of people in this role due to the challenge in
 doing so, but it is easy to identify many such individuals through
 their actions on GitHub and in our [community

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -53,7 +53,7 @@ At present, the Chapel subteam leads are as follows:
 * GPU: [Engin Kayraklioglu](https://github.com/e-kayrakli)
 * Performance: [Andy Stone](https://github.com/stonea)
 * Runtime, Platform, and Portability: [John Hartman](https://github.com/jhh67)
-* User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)
+* User Support: [Lydia Duncan](https://github.com/lydia-duncan)
 
 
 Committers

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ feel encouraged to capture those in an issue on this repository, or to
 
 ## Technical Leadership
 
-**Technical Lead:** [Brad Chamberlain](bradcray)
+**Technical Lead:** [Brad Chamberlain](https://github.com/bradcray)
 
 Role: Generally speaking, the role of the project technical lead has
 been to help guide decisions for the project in ways that are
@@ -47,7 +47,7 @@ At present, the Chapel subteam leads are as follows:
 * Community Management: [Brandon Neth](https://github.com/brandon-neth)
 * Compiler: [Ben Harshbarger](https://github.com/benharsh)
 * DevOps: [Tim Zinsky](https://github.com/tzinsky)
-* GPU: [Engin Kayraklioglu](e-kayrakli)
+* GPU: [Engin Kayraklioglu](https://github.com/e-kayrakli)
 * Performance: [Andy Stone](https://github.com/stonea)
 * Runtime / Platform / Portability: [John Hartman](https://github.com/jhh67)
 * User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,145 @@
-This is a placeholder governance file for the chapel-lang organization.
+# Governance of the Chapel Project
 
-TODO: Complete its contents
+This file describes the current governance of the Chapel Language
+project, covering both the language's definition and the code base
+implementing its compiler, library modules, and runtime.  It was last
+updated in January 2025.
+
+We anticipate improving the Chapel project's governance, with the aim
+of making it more of a community-governed project, over time.  If this
+is of interest to you, please let us know.  If you have specific
+requests with respect to how the project is governed, please open an
+issue on this repository.
+
+
+## Technical Leadership
+
+**Technical Lead:** [Brad Chamberlain](bradcray)
+
+Role: Generally speaking, the role of the project technical lead is to
+help guide technical decisions for the project in ways that are
+technically sound, responsive to user needs and concerns, cognizant of
+the project's history and past direction, and compatible with other
+decisions being made across the project.  As a founding member of the
+Chapel project who has been continually involved with it since the
+outset, Brad has served in this role since ~2006, making him something
+like the project's BDFL.
+
+
+**Subteam Leads**
+
+Role: As the scope of the Chapel project has grown, a number of
+subteams have been formed to focus on specific initiatives at finer
+granularities.  Generally speaking, these subteam leads have a great
+deal of latitude in making decisions supporting their goals, but are
+encouraged to keep the technical lead in the loop, particularly for
+decisions that are contentious, represent a significant change in
+direction, or have the possibility of impacting other subteams.
+
+At present, the subteam leads are as follows:
+
+* Community Management: [Brandon Neth](https://github.com/brandon-neth)
+* Compiler: [Ben Harshbarger](https://github.com/benharsh)
+* DevOps: [Tim Zinsky](https://github.com/tzinsky)
+* GPU: [Engin Kayraklioglu](e-kayrakli)
+* Performance: [Andy Stone](https://github.com/stonea)
+* Runtime / Platform / Portability: [John Hartman](https://github.com/jhh67)
+* User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)
+
+
+**Core Contributors**
+
+Role: Core contributors are those who have merge privileges to the
+[main Chapel repository](https://github.com/chapel-lang/chapel).
+These team members are expected to participate in reviewing PRs for
+appropriateness, consistency, and potential security issues.  Core
+contributors are also typically expected to help with triaging
+failures in the nightly regression tests, though exceptions are often
+made for core contributors who are also serving as managers on the
+team, focusing on DevOps or Build/Test/Release issues, or spending
+most of their time on other projects.
+
+All PRs are expected to be reviewed by at least one core contributor
+other than the PR's author; specifically, PRs created by a core
+contributor should typically be reviewed by another core contributor.
+An exception exists for PRs considered "trivial"—so simple or
+straightforward that asking for a review would feel like a waste of a
+colleague's time rather than a benefit to the project.  When in doubt,
+a review should be requested.  Core contributors who don't feel
+confident reviewing a PR will typically call in additional core
+contributors to help with the review or provide additional thoughts.
+A core contributor who authors or merges a PR is typically responsible
+for any testing fallout caused by that PR, typically by involving the
+PR's author.  In some cases, the reviewing core contributor or another
+volunteer may step up to help out.
+
+At present, the list of core contributors includes all of the
+technical leaders listed previously, as well as:
+
+* [Jade Abraham](https://github.com/jabraham17)
+* [Soohoon Choi](https://github.com/soohoonchoi)
+* [Matt Drozt](https://github.com/MattToast)
+* [Daniel Fedorin](https://github.com/DanilaFe)
+* [Michael Ferguson](https://github.com/mppf)
+* [Abhishek Girish](https://github.com/agirish)
+* [Shreyas Khandekar](https://github.com/ShreyasKhandekar)
+* [Vass Litvinov](https://github.com/vasslitvinov)
+* [David Longnecker](https://github.com/dlongnecke-cray)
+* [Ben McDonald](https://github.com/bmcdonald3)
+* [Ahmad Rezaii](https://github.com/arezaii)
+* [Anna Rift](https://github.com/riftEmber)
+* [Elliot Ronaghan](https://github.com/ronawho)
+* [Michelle Strout](https://github.com/mstrout)
+* [Karlon West](https://github.com/karlonw)
+
+
+** Decision-Making **
+
+Generally speaking, decision-making on the Chapel project is done by
+the technical leadership and contributors in this section on a
+consensus basis, taking the opinions of end-users into account when
+the decision is likely to effect them.
+
+For non-trivial internal decisions, or initial explorations into
+public decisions, the project typically forms an ad hoc subteam of at
+least three core contributors to explore the topic and propose a
+solution, where anyone on the team is encouraged to participate if
+they are interested.  Once the subteam has reached a conclusion, it is
+summarized back to the full team.  Generally speaking, those who did
+not join the subteam are expected to go along with the subteam's
+decision, unless they have an insight or strong reason that the
+proposal is untenable, particularly if it involves factors the subteam
+was unaware of.  In practice, this happens only very rarely.
+
+Decisions that relate to the design of the language or libraries are
+captured and discussed on public [GitHub
+issues](https://github.com/chapel-lang/chapel/issues?q=is%3Aissue) as
+a means of soliciting input from the community. Many of these issues
+are opened or requested by users directly. Decisions that are
+particularly impactful to user codes are advertised directly to users
+to get their feedback by pointing them to the GitHub issues or
+contacting them directly.  For some of the most impactful changes, we
+have run polls and worked hard to involve as many users as possible in
+order to avoid surprises and attempt to develop a consensus community
+view.
+
+
+## Community Contributors
+
+Role: This role describes those who have contributed code or
+documentation changes that are part of the project's release
+artifacts, typically by directly opening a [pull request (PR) against
+the main project
+repository](https://github.com/chapel-lang/chapel/pulls) that contains
+their commits to improve the code base or documentation.  As noted
+above, such PRs must be reviewed and merged by a core contributor as a
+means of maintaining and improving the quality of the code base, and
+to help manage any fallout that may show up afterwards, such as
+failures or performance regressions in the nightly testing.
+
+Our project tracks the list of core and community contributors in the
+main repository's
+[CONTRIBUTORS.md](https://github.com/chapel-lang/chapel/blob/main/CONTRIBUTORS.md)
+file, separately identifying those who have contributed to the most
+recent release as a means of giving distinction to those who have been
+active most recently.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,4 +1,5 @@
-# Governance of the Chapel Project
+Governance of the Chapel Project
+================================
 
 This file describes the current governance of the Chapel Language
 project, covering both the language's definition and the code base
@@ -14,7 +15,8 @@ feel encouraged to capture those in an issue on this repository, or to
 [reach out to the community](https://chapel-lang.org/community/).
 
 
-## Technical Leadership
+Technical Leadership
+--------------------
 
 **Technical Lead:** [Brad Chamberlain](https://github.com/bradcray)
 
@@ -53,7 +55,8 @@ At present, the Chapel subteam leads are as follows:
 * User Support / Language Stabilization: [Lydia Duncan](https://github.com/lydia-duncan)
 
 
-## Core Contributors
+Core Contributors
+-----------------
 
 Role: Core contributors are those who have merge privileges to the
 [main Chapel repository](https://github.com/chapel-lang/chapel).
@@ -98,7 +101,8 @@ technical leaders listed previously, as well as:
 * [Karlon West](https://github.com/karlonw)
 
 
-## Decision-Making
+Decision-Making
+---------------
 
 Generally speaking, decision-making on the Chapel project is done by
 the technical leadership and core contributors in this section on a
@@ -130,7 +134,8 @@ order to avoid surprises and attempt to develop a consensus community
 view.
 
 
-## Community Contributors
+Community Contributors
+----------------------
 
 Role: This role describes those who have contributed code or
 documentation changes that are part of the project's release
@@ -155,7 +160,8 @@ recent release as a means of giving distinction to those who have been
 active most recently.
 
 
-## Community Collaborators and Users
+Community Collaborators and Users
+---------------------------------
 
 Role: This role describes those who are active in the community and
 aid us in making the Chapel language and implementation better through

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# .github
-Special github repo for org-wide files and defaults for repos
+Chapel Governance
+=================
+
+Chapel is a programming language that productively supports parallel
+programming for multi-core CPUs and GPUs from laptops to
+supercomputers.
+
+This repository is the authoritative location for Chapel governance.
+Our current governance model, including roles, who holds them, and our
+decision-making process is documented in
+[GOVERNANCE.md](GOVERNANCE.md).
+
+License
+-------
+By default, repositories in the Chapel project are distributed under
+the terms of the Apache License (Version 2.0) unless the repository
+has a license file that overrides this default.


### PR DESCRIPTION
Our application to HPSF is contingent on having a documented capture of our governance process.  This is something that our project hasn't had in the public sphere before, so I've started this new repo (which I understand is the LF convention) and added an initial GOVERNANCE.md file that outlines our governance model as I understand it today.  @mppf and @e-kayrakli reviewed my first draft and offered commentary that improved it and helped evolve it toward its current state.

As noted in the opening paragraphs, this PR isn't meant to be the final word on Chapel governance.  Specifically, we anticipate enlarging the community's role in the governance model over time going forward.  In addition, we anticipate continuing to improve our description of the current governance model as documented here as more people read and provide feedback on it.

This PR also includes a basic README for this project, modeled to an extent on those of [Kokkos](https://github.com/kokkos/governance/tree/main#readme) and [Spack](https://github.com/spack/governance/tree/main#readme).